### PR TITLE
Fix infinite loop in GeoIP netfilter backfill

### DIFF
--- a/backend/app/migrations.py
+++ b/backend/app/migrations.py
@@ -799,20 +799,26 @@ def backfill_geoip_netfilter(db: Session):
         while rows:
             for row in rows:
                 geo = _geoip_service.lookup_ip(row.ip)
-                if geo.get('country_code'):
-                    db.execute(text("""
-                        UPDATE netfilter_logs 
-                        SET country_code = :cc, country_name = :cn, city = :city, asn = :asn, asn_org = :ao
-                        WHERE id = :id
-                    """), {
-                        "cc": geo.get('country_code'),
-                        "cn": geo.get('country_name'),
-                        "city": geo.get('city'),
-                        "asn": geo.get('asn'),
-                        "ao": geo.get('asn_org'),
-                        "id": row.id
-                    })
-                    updated += 1
+                country_code = geo.get('country_code') or 'ZZ'
+
+                db.execute(text("""
+                    UPDATE netfilter_logs
+                    SET country_code = :cc,
+                        country_name = :cn,
+                        city = :city,
+                        asn = :asn,
+                        asn_org = :ao
+                    WHERE id = :id
+                """), {
+                    "cc": country_code,
+                    "cn": geo.get('country_name') or 'Unknown',
+                    "city": geo.get('city'),
+                    "asn": geo.get('asn'),
+                    "ao": geo.get('asn_org'),
+                    "id": row.id
+                })
+
+                updated += 1
             
             db.commit()
             


### PR DESCRIPTION
## Problem

Application startup can hang indefinitely inside:

```python
backfill_geoip_netfilter(db)
```

The loop condition is:

```sql
WHERE ip IS NOT NULL AND country_code IS NULL
```

However, rows are only updated when:

```python
if geo.get('country_code'):
```

returns true.

If GeoIP lookup returns no `country_code` for an IP:
- the row is never updated
- `country_code` remains `NULL`
- the same row is selected again forever
- startup blocks indefinitely

This affects installations with unresolved, private, malformed, or otherwise non-resolvable IP addresses.

---

## Root Cause

The loop logic combines:

Selection predicate:

```sql
WHERE country_code IS NULL
```

with conditional update logic:

```python
if geo.get('country_code'):
```

Rows without a successful GeoIP result are therefore never marked as processed and permanently remain inside the result set.

The loop:

```python
while rows:
```

never terminates because the same unresolved rows are fetched repeatedly.

---

## Fix

Always update the row, even when no GeoIP result exists.

Fallback values are assigned:

```python
country_code = geo.get('country_code') or 'ZZ'
```

and:

```python
"cn": geo.get('country_name') or 'Unknown'
```

This guarantees that processed rows no longer match:

```sql
WHERE country_code IS NULL
```

and therefore leave the migration queue permanently.

---

## Result

- startup no longer hangs indefinitely
- unresolved IPs are processed exactly once
- migration becomes deterministic
- installations with large historical datasets can complete startup normally
- CPU/database load caused by endless reprocessing is eliminated

---

## Reproduction

The issue can be reproduced with at least one row where:

```sql
ip IS NOT NULL
AND country_code IS NULL
```

and GeoIP lookup returns no `country_code`.

In this situation:
- `UPDATE` is skipped
- row remains selectable
- loop repeats forever

Observed behavior:
- application stuck at:
  `Waiting for application startup`
- startup never completes
- container remains unhealthy indefinitely

---

## Additional Notes

The problematic call path is:

```python
run_migrations()
 -> backfill_geoip_netfilter(db)
```

inside application startup (`lifespan()`).

The issue is independent of PostgreSQL performance and reproducible with otherwise healthy databases.


Fixes #56