### PR TITLE
Add SMTP abuse protection and security monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ A modern, self-hosted dashboard for monitoring, analyzing, and managing your mai
 - **OAuth2/OIDC** — supports any standard provider (Mailcow, Keycloak, Auth0, Google, etc.)
 - Both methods can be enabled simultaneously
 
+### 🚨 SMTP Abuse Protection
+- Rolling-window outbound message threshold
+- SMTP-only blocking; IMAP and SOGo remain available
+- App-password revocation and user security notifications
+- Whitelist and manual block/re-enable controls
+- [SMTP Abuse Protection guide](documentation/SMTP_Abuse_Protection.md)
+
 ---
 
 ## Quick Start
@@ -131,6 +138,8 @@ docker compose up -d
 📖 **Full installation guide:** [Getting Started](documentation/GETTING_STARTED.md)
 
 📘 **Technical Overview: Email Authentication & Monitoring:** How can **mailcow-logs-viewer** help you with this [Read more](documentation/Email_Authentication_Monitoring.md)
+
+🛡️ **SMTP Abuse Protection:** Rolling-window SMTP controls, whitelist management, and deployment instructions [Read more](documentation/SMTP_Abuse_Protection.md)
 
 ---
 
@@ -161,11 +170,14 @@ All settings via environment variables or the **web UI** (when `SETTINGS_EDIT_VI
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MAILCOW_API_KEY_RW` | (empty) | Read-Write API key — enables edit features (Fail2Ban, Queue, Quarantine, Rspamd sync) |
+| `MAILCOW_API_KEY_RW` | (empty) | Read-Write API key — enables edit features (Fail2Ban, Queue, Quarantine, Rspamd sync, SMTP abuse protection) |
 | `FETCH_INTERVAL` | `60` | Seconds between log fetches |
 | `RETENTION_DAYS` | `7` | Days to keep logs |
 | `RSPAMD_PASSWORD` | (empty) | Rspamd password — enables Spam Filter maps editor |
 | `SUPPRESSION_ENABLED` | `true` | Enable automatic email suppression |
+| `SMTP_ABUSE_ENABLED` | `false` | Enable automatic SMTP blocking for mailboxes exceeding the message threshold |
+| `SMTP_ABUSE_THRESHOLD` | `100` | Maximum outbound messages allowed in the rolling window |
+| `SMTP_ABUSE_WINDOW_MINUTES` | `60` | Rolling window used by SMTP abuse protection |
 | `BASIC_AUTH_ENABLED` | `true` | Enable HTTP Basic Authentication |
 | `SETTINGS_EDIT_VIA_UI_ENABLED` | `true` | Allow managing settings from the web UI |
 | `TZ` | `UTC` | Timezone |
@@ -181,6 +193,7 @@ All settings via environment variables or the **web UI** (when `SETTINGS_EDIT_VI
 | [Getting Started](documentation/GETTING_STARTED.md) | Installation and setup guide |
 | [ENV Settings](documentation/ENV_Settings.md) | Complete environment variables reference |
 | [API Documentation](documentation/API.md) | REST API reference |
+| [SMTP Abuse Protection](documentation/SMTP_Abuse_Protection.md) | SMTP abuse protection setup and operation |
 | [Settings UI](documentation/Settings_UI.md) | Web-based settings editor guide |
 | [OAuth2 Configuration](documentation/OAuth2_Configuration.md) | OAuth2/OIDC setup guide |
 | [Upgrade to V2](documentation/UpdateV2.md) | Migration guide from V1 |

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,12 @@ class Settings(BaseSettings):
         default="",
         description="Comma-separated list of email addresses to hide from logs"
     )
+
+    # SMTP abuse protection
+    smtp_abuse_enabled: bool = Field(default=False, env="SMTP_ABUSE_ENABLED", description="Automatically block mailboxes exceeding the SMTP message threshold")
+    smtp_abuse_threshold: int = Field(default=100, env="SMTP_ABUSE_THRESHOLD", description="Outbound messages allowed in the rolling window")
+    smtp_abuse_window_minutes: int = Field(default=60, env="SMTP_ABUSE_WINDOW_MINUTES", description="Rolling SMTP abuse window in minutes")
+    smtp_abuse_help_address: str = Field(default="", env="SMTP_ABUSE_HELP_ADDRESS", description="Support address included in SMTP abuse notifications")
     
     # Fetch Configuration
     fetch_interval: int = Field(default=60, description="Seconds between log fetches")

--- a/backend/app/mailcow_api.py
+++ b/backend/app/mailcow_api.py
@@ -5,6 +5,7 @@ Handles authentication and API calls to mailcow instance
 import asyncio
 import httpx
 import logging
+from urllib.parse import quote
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 from tenacity import retry, stop_after_attempt, wait_exponential
@@ -656,6 +657,29 @@ class MailcowAPI:
         except MailcowAPIError as e:
             logger.error(f"Failed to fetch mailboxes: {e}")
             return []
+
+    async def edit_mailbox(self, mailbox: str, attributes: Dict[str, Any]) -> Any:
+        """Update selected mailbox attributes using the read-write API key."""
+        return await self._make_rw_request(
+            "/api/v1/edit/mailbox",
+            method="POST",
+            json={"attr": attributes, "items": [mailbox]}
+        )
+
+    async def get_app_passwords(self, mailbox: str) -> List[Dict[str, Any]]:
+        """List app passwords for a mailbox."""
+        data = await self._make_request(f"/api/v1/get/app-passwd/all/{quote(mailbox, safe='@')}")
+        return data if isinstance(data, list) else []
+
+    async def delete_app_passwords(self, ids: List[str]) -> Any:
+        """Delete one or more app passwords using the read-write API key."""
+        if not ids:
+            return []
+        return await self._make_rw_request(
+            "/api/v1/delete/app-passwd",
+            method="POST",
+            json=ids
+        )
     
     async def get_aliases(self) -> List[Dict[str, Any]]:
         """
@@ -887,7 +911,7 @@ class MailcowAPI:
     async def unban_fail2ban(self, ip: str) -> Dict[str, Any]:
         """
         Unban an IP address in Fail2Ban on mailcow using the Read-Write API key.
-        
+
         Args:
             ip: IP address to unban
         

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ from .routers import (
     rspamd_maps as rspamd_maps_router,
     suppressions as suppressions_router,
     quarantine_rules as quarantine_rules_router,
+    smtp_abuse as smtp_abuse_router,
 )
 from .migrations import run_migrations
 from .auth import BasicAuthMiddleware
@@ -250,6 +251,7 @@ app.include_router(raw_logs_router.router, prefix="/api", tags=["Raw Logs"])
 app.include_router(rspamd_maps_router.router, prefix="/api", tags=["Rspamd Maps"])
 app.include_router(suppressions_router.router, prefix="/api", tags=["Suppressions"])
 app.include_router(quarantine_rules_router.router, tags=["Quarantine Rules"])
+app.include_router(smtp_abuse_router.router, prefix="/api", tags=["SMTP Abuse"])
 
 # WebSocket endpoint needs root-level mount (not under /api prefix)
 # The router contains /ws/raw-logs which should be accessible at wss://host/ws/raw-logs  # nosemgrep: javascript.lang.security.detect-insecure-websocket.detect-insecure-websocket

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -634,6 +634,30 @@ class SpamSuppression(Base):
         return f"<SpamSuppression(email={self.email}, reason={self.reason}, active={self.active}, bounces={self.bounce_count})>"
 
 
+class SMTPAbuseWhitelist(Base):
+    __tablename__ = "smtp_abuse_whitelist"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), unique=True, nullable=False, index=True)
+    notes = Column(Text)
+    active = Column(Boolean, default=True, nullable=False, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SMTPAbuseAction(Base):
+    __tablename__ = "smtp_abuse_actions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String(255), nullable=False, index=True)
+    message_count = Column(Integer, nullable=False)
+    threshold = Column(Integer, nullable=False)
+    window_minutes = Column(Integer, nullable=False)
+    action = Column(String(30), nullable=False, default="blocked")
+    automatic = Column(Boolean, nullable=False, default=True)
+    operator = Column(String(255))
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+
 class QuarantineRule(Base):
     """
     Quarantine auto-processing rules.

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -404,6 +404,14 @@ def get_settings_info(db: Session = Depends(get_db)):
                     "status": jobs_status.get('cleanup_deferred_queue', {}).get('status', 'idle') if (settings.is_feature_enabled('spam-filter') and settings.suppression_enabled and settings.queue_cleanup_enabled) else 'disabled',
                     "last_run": format_datetime_utc(jobs_status.get('cleanup_deferred_queue', {}).get('last_run')) if (settings.is_feature_enabled('spam-filter') and settings.suppression_enabled and settings.queue_cleanup_enabled) else None,
                     "error": jobs_status.get('cleanup_deferred_queue', {}).get('error') if (settings.is_feature_enabled('spam-filter') and settings.suppression_enabled and settings.queue_cleanup_enabled) else None
+                },
+                "smtp_abuse": {
+                    "interval": "1 minute" if (settings.smtp_abuse_enabled and mailcow_api.has_rw_key) else ("Disabled (SMTP abuse protection off)" if not settings.smtp_abuse_enabled else "Disabled (no RW API key)"),
+                    "description": "Checks rolling outbound message counts and disables SMTP for abusive mailboxes",
+                    "enabled": settings.smtp_abuse_enabled and mailcow_api.has_rw_key,
+                    "status": jobs_status.get('smtp_abuse', {}).get('status', 'idle') if (settings.smtp_abuse_enabled and mailcow_api.has_rw_key) else 'disabled',
+                    "last_run": format_datetime_utc(jobs_status.get('smtp_abuse', {}).get('last_run')) if (settings.smtp_abuse_enabled and mailcow_api.has_rw_key) else None,
+                    "error": jobs_status.get('smtp_abuse', {}).get('error') if (settings.smtp_abuse_enabled and mailcow_api.has_rw_key) else None
                 }
             },
             "smtp_configuration": {
@@ -913,6 +921,7 @@ def trigger_job(job_name: str, background_tasks: BackgroundTasks):
     - blacklist_check: Check server IP against blacklists
     - fetch_raw_logs: Fetch raw logs from mailcow services
     - cleanup_raw_logs: Remove raw logs older than retention period
+    - smtp_abuse: Check outbound activity and apply SMTP abuse protection
     """
     # Import job functions here to avoid circular imports
     from ..scheduler import (
@@ -935,7 +944,8 @@ def trigger_job(job_name: str, background_tasks: BackgroundTasks):
         sync_suppressions_to_rspamd_job,
         expire_suppressions_job,
         process_quarantine_rules_job,
-        cleanup_deferred_queue_job
+        cleanup_deferred_queue_job,
+        smtp_abuse_job
     )
     from ..raw_logs_worker import fetch_raw_service_logs, cleanup_raw_service_logs
     
@@ -963,6 +973,7 @@ def trigger_job(job_name: str, background_tasks: BackgroundTasks):
         'expire_suppressions': ('expire_suppressions', expire_suppressions_job, False),
         'process_quarantine_rules': ('process_quarantine_rules', process_quarantine_rules_job, False),
         'cleanup_deferred_queue': ('cleanup_deferred_queue', cleanup_deferred_queue_job, False),
+        'smtp_abuse': ('smtp_abuse', smtp_abuse_job, True),
         'fetch_raw_logs': ('fetch_raw_logs', fetch_raw_service_logs, True),
         'cleanup_raw_logs': ('cleanup_raw_logs', cleanup_raw_service_logs, True),
     }

--- a/backend/app/routers/smtp_abuse.py
+++ b/backend/app/routers/smtp_abuse.py
@@ -1,0 +1,242 @@
+"""SMTP abuse detection, whitelist management, and mailbox controls."""
+import asyncio
+import logging
+import re
+from datetime import datetime, timedelta
+from typing import Optional, List
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, field_validator, Field
+from sqlalchemy import func, case
+
+from ..config import settings
+from ..database import get_db_context
+from ..mailcow_api import mailcow_api
+from ..models import MessageCorrelation, SMTPAbuseAction, SMTPAbuseWhitelist
+from ..services.smtp_service import send_notification_email
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/smtp-abuse")
+
+
+class WhitelistRequest(BaseModel):
+    email: str
+    notes: Optional[str] = None
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, value: str) -> str:
+        value = value.strip().lower()
+        if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", value):
+            raise ValueError("Invalid email format")
+        return value
+
+
+class WhitelistBulkRequest(BaseModel):
+    emails: List[str] = Field(default_factory=list)
+
+
+def normalized(email: str) -> str:
+    return email.strip().lower()
+
+
+def require_control_access() -> None:
+    """Keep the write API consistent with the locked Security UI."""
+    if not settings.smtp_abuse_enabled:
+        raise HTTPException(status_code=403, detail="SMTP abuse protection is disabled")
+    if not mailcow_api.has_rw_key:
+        raise HTTPException(status_code=503, detail="MAILCOW_API_KEY_RW is required")
+
+
+async def revoke_app_passwords(email: str) -> int:
+    entries = await mailcow_api.get_app_passwords(email)
+    ids = [str(entry["id"]) for entry in entries if isinstance(entry, dict) and entry.get("id") is not None]
+    if ids:
+        await mailcow_api.delete_app_passwords(ids)
+    return len(ids)
+
+
+async def notify_blocked(email: str, count: int, threshold: int, window: int) -> None:
+    if not settings.smtp_enabled or not settings.smtp_from:
+        logger.warning("SMTP abuse notification skipped: SMTP notifications are not configured")
+        return
+    subject = "Security alert for your email account"
+    text = f"""SMTP sending has been temporarily disabled for {email}.
+
+We detected {count} sent messages during the last {window} minutes. The configured limit is {threshold}.
+IMAP access remains enabled. Please change your password and/or revoke your app passwords.
+
+Contact {settings.smtp_abuse_help_address or "your support team"} if you need assistance.
+"""
+    await asyncio.to_thread(send_notification_email, email, subject, text, text.replace("\n", "<br>"))
+
+
+async def block_mailbox(email: str, count: int, automatic: bool = False, operator: Optional[str] = None):
+    email = normalized(email)
+    await mailcow_api.edit_mailbox(email, {"smtp_access": "0"})
+    revoked = 0
+    revoke_error = None
+    try:
+        revoked = await revoke_app_passwords(email)
+    except Exception as exc:
+        revoke_error = str(exc)
+        logger.error("Could not revoke app passwords for %s: %s", email, exc, exc_info=True)
+    try:
+        await notify_blocked(email, count, settings.smtp_abuse_threshold, settings.smtp_abuse_window_minutes)
+    except Exception as exc:
+        logger.error("Could not send SMTP abuse notification to %s: %s", email, exc, exc_info=True)
+    with get_db_context() as db:
+        db.add(SMTPAbuseAction(
+            email=email,
+            message_count=count,
+            threshold=settings.smtp_abuse_threshold,
+            window_minutes=settings.smtp_abuse_window_minutes,
+            action="blocked",
+            automatic=automatic,
+            operator=operator or "system",
+        ))
+    return {"email": email, "smtp_access": False, "app_passwords_revoked": revoked,
+            "app_password_revoke_failed": revoke_error is not None}
+
+
+@router.get("/status")
+async def status(limit: int = Query(200, ge=1, le=1000)):
+    cutoff = datetime.utcnow() - timedelta(minutes=settings.smtp_abuse_window_minutes)
+    mailbox_access = {}
+    try:
+        mailboxes = await mailcow_api.get_mailboxes()
+        for mailbox in mailboxes:
+            address = mailbox.get("username")
+            if address:
+                # Mailcow versions expose access flags inside `attributes`.
+                # Some versions also expose them at the mailbox top level.
+                attributes = mailbox.get("attributes") or {}
+                access = mailbox.get("smtp_access", attributes.get("smtp_access", 1))
+                mailbox_access[normalized(address)] = not (access is False or str(access).lower() in ("0", "false", "no"))
+    except Exception as exc:
+        logger.warning("Could not load mailbox SMTP access states: %s", exc)
+
+    with get_db_context() as db:
+        counts = db.query(
+            MessageCorrelation.sender.label("email"),
+            func.count(MessageCorrelation.id).label("message_count"),
+            func.sum(case((func.lower(MessageCorrelation.direction) == "outbound", 1), else_=0)).label("outbound_count")
+        ).filter(
+            func.lower(MessageCorrelation.direction).in_(["outbound", "internal"]),
+            MessageCorrelation.first_seen >= cutoff,
+            MessageCorrelation.sender.isnot(None),
+        ).group_by(MessageCorrelation.sender).order_by(func.count(MessageCorrelation.id).desc()).limit(limit).all()
+        whitelist = {row.email for row in db.query(SMTPAbuseWhitelist).filter(SMTPAbuseWhitelist.active.is_(True)).all()}
+        latest_action = db.query(
+            SMTPAbuseAction.email.label("email"),
+            func.max(SMTPAbuseAction.created_at).label("latest_created_at")
+        ).group_by(SMTPAbuseAction.email).subquery()
+        actions = db.query(SMTPAbuseAction).join(
+            latest_action,
+            (SMTPAbuseAction.email == latest_action.c.email) &
+            (SMTPAbuseAction.created_at == latest_action.c.latest_created_at)
+        ).all()
+        # Do not treat every mailbox with smtp_access=0 as an abuse case.
+        # Incoming-only mailboxes (for example DMARC report mailboxes) also
+        # intentionally have SMTP disabled. Only show mailboxes whose latest
+        # recorded action in this system is a block.
+        closed_by_protection = {normalized(action.email) for action in actions if action.action == "blocked"}
+        count_by_email = {normalized(row.email): int(row.message_count) for row in counts if row.email}
+        outbound_by_email = {normalized(row.email): int(row.outbound_count or 0) for row in counts if row.email}
+        visible_emails = [
+            email for email in count_by_email
+            if mailbox_access.get(email, True) or email in closed_by_protection
+        ]
+        for email, smtp_open in mailbox_access.items():
+            if not smtp_open and email in closed_by_protection and email not in count_by_email:
+                visible_emails.append(email)
+        return {
+            "enabled": settings.smtp_abuse_enabled,
+            "threshold": settings.smtp_abuse_threshold,
+            "window_minutes": settings.smtp_abuse_window_minutes,
+            "mailboxes": [
+                {"email": email, "message_count": count_by_email.get(email, 0),
+                 "whitelisted": email in whitelist,
+                 "outbound_count": outbound_by_email.get(email, 0),
+                 "over_threshold": outbound_by_email.get(email, 0) > settings.smtp_abuse_threshold,
+                 "smtp_access": mailbox_access.get(email, True)}
+                for email in visible_emails
+            ],
+            "whitelist": sorted(whitelist),
+        }
+
+
+@router.get("/whitelist")
+async def get_whitelist():
+    with get_db_context() as db:
+        return [{"email": row.email, "notes": row.notes, "active": row.active}
+                for row in db.query(SMTPAbuseWhitelist).filter(SMTPAbuseWhitelist.active.is_(True)).order_by(SMTPAbuseWhitelist.email).all()]
+
+
+@router.post("/whitelist")
+async def add_whitelist(request: WhitelistRequest):
+    require_control_access()
+    email = normalized(str(request.email))
+    with get_db_context() as db:
+        row = db.query(SMTPAbuseWhitelist).filter(SMTPAbuseWhitelist.email == email).first()
+        if row:
+            row.active = True
+            row.notes = request.notes
+        else:
+            db.add(SMTPAbuseWhitelist(email=email, notes=request.notes, active=True))
+    return {"email": email, "active": True}
+
+
+@router.put("/whitelist")
+async def replace_whitelist(request: WhitelistBulkRequest):
+    require_control_access()
+    emails = set()
+    for value in request.emails:
+        email = normalized(value)
+        if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email):
+            raise HTTPException(status_code=422, detail=f"Invalid email format: {value}")
+        emails.add(email)
+
+    with get_db_context() as db:
+        existing = {row.email: row for row in db.query(SMTPAbuseWhitelist).all()}
+        for email, row in existing.items():
+            row.active = email in emails
+        for email in emails - set(existing):
+            db.add(SMTPAbuseWhitelist(email=email, active=True))
+    return {"active": sorted(emails), "count": len(emails)}
+
+
+@router.delete("/whitelist/{email}")
+async def remove_whitelist(email: str):
+    require_control_access()
+    email = normalized(email)
+    with get_db_context() as db:
+        row = db.query(SMTPAbuseWhitelist).filter(SMTPAbuseWhitelist.email == email).first()
+        if not row:
+            raise HTTPException(status_code=404, detail="Email is not on the whitelist")
+        row.active = False
+    return {"email": email, "active": False}
+
+
+@router.post("/mailboxes/{email}/block")
+async def manual_block(email: str):
+    require_control_access()
+    with get_db_context() as db:
+        count = db.query(MessageCorrelation).filter(
+            func.lower(MessageCorrelation.sender) == normalized(email),
+            func.lower(MessageCorrelation.direction) == "outbound",
+            MessageCorrelation.first_seen >= datetime.utcnow() - timedelta(minutes=settings.smtp_abuse_window_minutes)
+        ).count()
+    return await block_mailbox(email, count, automatic=False, operator="manual")
+
+
+@router.post("/mailboxes/{email}/unblock")
+async def manual_unblock(email: str):
+    require_control_access()
+    await mailcow_api.edit_mailbox(normalized(email), {"smtp_access": "1"})
+    with get_db_context() as db:
+        db.add(SMTPAbuseAction(email=normalized(email), message_count=0,
+                               threshold=settings.smtp_abuse_threshold,
+                               window_minutes=settings.smtp_abuse_window_minutes,
+                               action="unblocked", automatic=False, operator="manual"))
+    return {"email": normalized(email), "smtp_access": True}

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -15,13 +15,13 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy.orm import Session
-from sqlalchemy import desc, or_
+from sqlalchemy import desc, or_, func
 from sqlalchemy.exc import IntegrityError
 
 from .config import settings, set_cached_active_domains
 from .database import get_db_context, SessionLocal
 from .mailcow_api import mailcow_api
-from .models import PostfixLog, RspamdLog, NetfilterLog, MessageCorrelation, DMARCSync, DomainDNSCheck, MailboxStatistics, AliasStatistics, MonitoredHost, BlacklistCheck, DMARCReport, DMARCRecord, TLSReport, TLSReportPolicy, SpamSuppression
+from .models import PostfixLog, RspamdLog, NetfilterLog, MessageCorrelation, DMARCSync, DomainDNSCheck, MailboxStatistics, AliasStatistics, MonitoredHost, BlacklistCheck, DMARCReport, DMARCRecord, TLSReport, TLSReportPolicy, SpamSuppression, SMTPAbuseWhitelist, SMTPAbuseAction
 from .correlation import detect_direction, parse_postfix_message
 from .routers.domains import check_domain_dns, save_dns_check_to_db
 from .services.dmarc_imap_service import sync_dmarc_reports_from_imap
@@ -107,6 +107,7 @@ def reschedule_interval_jobs():
 
         # Reschedule suppression jobs based on current settings
         _reschedule_suppression_jobs()
+        _reschedule_smtp_abuse_job()
 
     except Exception as e:
         logger.warning("Failed to reschedule interval jobs: %s", e)
@@ -187,6 +188,28 @@ def _reschedule_suppression_jobs():
         except Exception:
             pass
 
+
+def _reschedule_smtp_abuse_job():
+    """Add or remove SMTP abuse protection when settings are reloaded."""
+    if not scheduler.running:
+        return
+    if settings.smtp_abuse_enabled and mailcow_api.has_rw_key:
+        scheduler.add_job(
+            smtp_abuse_job,
+            trigger=IntervalTrigger(minutes=1),
+            id='smtp_abuse',
+            name='SMTP Abuse Protection',
+            replace_existing=True,
+            max_instances=1,
+        )
+        logger.info("   [SMTP ABUSE] Protection scheduled (every minute; threshold: %s/%s minutes)",
+                    settings.smtp_abuse_threshold, settings.smtp_abuse_window_minutes)
+    else:
+        try:
+            scheduler.remove_job('smtp_abuse')
+        except Exception:
+            pass
+
 # Job execution tracking
 job_status = {
     'fetch_logs': {'last_run': None, 'status': 'idle', 'error': None},
@@ -211,7 +234,54 @@ job_status = {
     'expire_suppressions': {'last_run': None, 'status': 'idle', 'error': None},
     'process_quarantine_rules': {'last_run': None, 'status': 'idle', 'error': None},
     'cleanup_deferred_queue': {'last_run': None, 'status': 'idle', 'error': None},
+    'smtp_abuse': {'last_run': None, 'status': 'idle', 'error': None},
 }
+
+
+async def smtp_abuse_job():
+    """Block non-whitelisted mailboxes exceeding the rolling outbound threshold."""
+    update_job_status('smtp_abuse', 'running')
+    if not settings.smtp_abuse_enabled or not mailcow_api.has_rw_key:
+        update_job_status('smtp_abuse', 'success')
+        return
+    try:
+        from .routers.smtp_abuse import block_mailbox
+        cutoff = datetime.utcnow() - timedelta(minutes=settings.smtp_abuse_window_minutes)
+        with get_db_context() as db:
+            whitelist = {row.email for row in db.query(SMTPAbuseWhitelist).filter(SMTPAbuseWhitelist.active.is_(True)).all()}
+            candidates = db.query(
+                MessageCorrelation.sender.label('email'),
+                func.count(MessageCorrelation.id).label('message_count')
+            ).filter(
+                func.lower(MessageCorrelation.direction) == 'outbound',
+                MessageCorrelation.first_seen >= cutoff,
+                MessageCorrelation.sender.isnot(None),
+            ).group_by(MessageCorrelation.sender).having(
+                func.count(MessageCorrelation.id) > settings.smtp_abuse_threshold
+            ).all()
+            latest_action = db.query(
+                SMTPAbuseAction.email.label('email'),
+                func.max(SMTPAbuseAction.created_at).label('latest_created_at')
+            ).group_by(SMTPAbuseAction.email).subquery()
+            blocked_state = db.query(SMTPAbuseAction).join(
+                latest_action,
+                (SMTPAbuseAction.email == latest_action.c.email) &
+                (SMTPAbuseAction.created_at == latest_action.c.latest_created_at)
+            ).all()
+            blocked_recently = {row.email for row in blocked_state if row.action == 'blocked'}
+        for candidate in candidates:
+            email = candidate.email.lower().strip()
+            if email in whitelist or email in blocked_recently:
+                continue
+            await block_mailbox(email, int(candidate.message_count), automatic=True, operator='smtp-abuse')
+            logger.warning(f"[SMTP ABUSE] Blocked {email} after {candidate.message_count} messages in {settings.smtp_abuse_window_minutes} minutes")
+        update_job_status('smtp_abuse', 'success')
+    except asyncio.CancelledError:
+        update_job_status('smtp_abuse', 'success')
+        raise
+    except Exception as e:
+        logger.error(f"[SMTP ABUSE] Error: {e}", exc_info=True)
+        update_job_status('smtp_abuse', 'failed', str(e))
 
 # Number of hosts that were listed on actionable blacklists in the previous blacklist check run (for "cleared" notification)
 _blacklist_last_listed_actionable_count = 0
@@ -3113,6 +3183,21 @@ def start_scheduler():
             logger.info("Scheduled alias statistics job (interval: 5 minutes)")
         else:
             logger.info("   [FEATURE] Mailbox Stats feature disabled — skipping mailbox/alias stats jobs")
+
+        # Job 13b: SMTP Abuse Protection (disabled by default)
+        if settings.smtp_abuse_enabled and mailcow_api.has_rw_key:
+            scheduler.add_job(
+                smtp_abuse_job,
+                trigger=IntervalTrigger(minutes=1),
+                id='smtp_abuse',
+                name='SMTP Abuse Protection',
+                replace_existing=True,
+                max_instances=1,
+            )
+            logger.info("   [SMTP ABUSE] Protection: every minute (threshold: %s/%s minutes)",
+                        settings.smtp_abuse_threshold, settings.smtp_abuse_window_minutes)
+        else:
+            logger.info("   [SMTP ABUSE] Protection disabled or read-write Mailcow API key unavailable")
 
         # Job 15: Blacklist Check (daily at 5 AM)
         if settings.is_feature_enabled('blacklist'):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
 
   # Main Application
   app:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: ghcr.io/shlomiporush/mailcow-logs-viewer:latest
     container_name: mailcow-logs-app
     restart: unless-stopped
@@ -28,6 +31,11 @@ services:
         condition: service_healthy
     ports:
       - "8080:8080"
+    # If Mailcow runs on the same Docker host, resolve its public hostname
+    # through the host gateway to avoid NAT/certificate issues. Set
+    # MAILCOW_HOSTNAME in the local .env; the example value is not committed.
+    extra_hosts:
+      - "${MAILCOW_HOSTNAME:-mailcow-host-gateway.invalid}:host-gateway"
     volumes:
       - mailcowlogs_data:/app/data
     networks:

--- a/documentation/API.md
+++ b/documentation/API.md
@@ -42,6 +42,7 @@ When authentication is enabled, all API endpoints (except public endpoints liste
     - [Rspamd Maps](#rspamd-maps)
     - [Suppressions](#suppressions)
 19. [Quarantine Auto-Rules](#quarantine-auto-rules)
+20. [SMTP Abuse Protection](#smtp-abuse-protection)
 
 ---
 
@@ -1595,6 +1596,18 @@ Update Fail2Ban configuration on mailcow. Requires the Read-Write API key (`MAIL
 - `400 Bad Request`: Invalid payload or mailcow rejected the update
 - `403 Forbidden`: Read-Write API key is not configured
 - `503 Service Unavailable`: Could not reach the mailcow API
+
+#### POST /fail2ban/unban
+
+Unban an active Fail2Ban network on mailcow. The request is proxied to
+mailcow's `POST /api/v1/delete/fail2ban` endpoint.
+
+**Request Body:**
+```json
+{
+  "ip": "203.0.113.7/32"
+}
+```
 
 #### RW Status Check
 
@@ -5222,3 +5235,25 @@ Get quarantine rule action history (paginated).
 **Notes:**
 - Logs are automatically pruned based on `QUARANTINE_RULES_LOG_RETENTION_DAYS` (default: 30)
 - Each entry represents one automated action taken by the scheduler
+
+## SMTP Abuse Protection
+
+These authenticated endpoints manage rolling outbound SMTP protection. Blocking changes only `smtp_access`; IMAP and SOGo remain enabled. The status view includes internal SMTP activity for visibility, while automatic blocking counts only `outbound` messages.
+
+- `GET /api/smtp-abuse/status` — message counts, threshold, and whitelist state.
+- `GET /api/smtp-abuse/whitelist` — list whitelist entries.
+- `POST /api/smtp-abuse/whitelist` — add or reactivate an entry; body: `{"email":"trusted@example.com","notes":"optional"}`.
+- `PUT /api/smtp-abuse/whitelist` — replace the active whitelist; body: `{"emails":["trusted@example.com","monitoring@example.com"]}`.
+- `DELETE /api/smtp-abuse/whitelist/{email}` — deactivate an entry.
+- `POST /api/smtp-abuse/mailboxes/{email}/block` — manually disable SMTP and revoke app passwords.
+- `POST /api/smtp-abuse/mailboxes/{email}/unblock` — re-enable SMTP only.
+
+Automatic enforcement runs once per minute when `SMTP_ABUSE_ENABLED=true` and a read-write Mailcow API key is configured.
+
+The job can also be started manually with:
+
+```text
+POST /api/settings/jobs/smtp_abuse/run
+```
+
+Write operations require `SMTP_ABUSE_ENABLED=true` and `MAILCOW_API_KEY_RW`. All endpoints are protected by the application authentication middleware; separate administrator roles are not currently enforced by this feature.

--- a/documentation/ENV_Settings.md
+++ b/documentation/ENV_Settings.md
@@ -34,9 +34,22 @@ These settings **must** be configured in your `.env` file:
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
+| `MAILCOW_HOSTNAME` | string | (unset) | Optional Docker host-gateway hostname. Set this only when Mailcow runs on the same Docker host as the viewer and the public route causes NAT or certificate problems. Do not set it for a separate Mailcow host |
 | `MAILCOW_API_KEY_RW` | string | (empty) | mailcow API key — **Read-Write** (optional). Generate a separate key from System → API with write permissions. Used only for edit operations (e.g. Fail2Ban settings). When not set, edit features are disabled |
 | `MAILCOW_API_VERIFY_SSL` | boolean | `true` | Verify SSL certificates when connecting to mailcow API. Set to `false` for development environments with self-signed certificates |
 | `MAILCOW_API_TIMEOUT` | integer | `30` | API request timeout in seconds |
+
+### Docker host-gateway routing
+
+When the viewer and Mailcow run on the same Docker host, the Mailcow hostname may need to resolve through Docker's host gateway. This avoids hairpin NAT and certificate-routing problems when the hostname normally resolves to a public address.
+
+Add the hostname to the local `.env` file:
+
+```env
+MAILCOW_HOSTNAME=mail.example.com
+```
+
+Leave `MAILCOW_HOSTNAME` unset when Mailcow runs on another host. In that case, `MAILCOW_URL` must resolve normally from the viewer container and its TLS certificate must be trusted. Do not disable SSL verification just to work around a routing problem.
 
 ---
 
@@ -90,6 +103,19 @@ These settings **must** be configured in your `.env` file:
 | `SMTP_PASSWORD` | string | (empty) | SMTP password |
 | `SMTP_FROM` | string | (empty) | From address for emails (defaults to SMTP user if not set) |
 | `SMTP_RELAY_MODE` | boolean | `false` | Relay mode - send emails without authentication (for local relay servers). When enabled, username and password are not required |
+
+## SMTP Abuse Protection
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SMTP_ABUSE_ENABLED` | boolean | `false` | Automatically disable SMTP for a mailbox after it exceeds the rolling outbound message threshold |
+| `SMTP_ABUSE_THRESHOLD` | integer | `100` | Maximum outbound messages allowed in the rolling window |
+| `SMTP_ABUSE_WINDOW_MINUTES` | integer | `60` | Rolling window used for counting outbound messages |
+| `SMTP_ABUSE_HELP_ADDRESS` | string | (empty) | Support address included in the security notification sent to a blocked mailbox |
+
+SMTP abuse protection requires `MAILCOW_API_KEY_RW`. It changes only the mailbox `smtp_access` setting, revokes app passwords, and leaves IMAP and SOGo enabled. Whitelist and manual block/unblock controls are available under **Security → Abuse Protection**.
+
+See [SMTP Abuse Protection](SMTP_Abuse_Protection.md) for the complete setup, API, notification, and deployment guide.
 
 ---
 

--- a/documentation/GETTING_STARTED.md
+++ b/documentation/GETTING_STARTED.md
@@ -23,6 +23,14 @@ MAILCOW_API_KEY=your_api_key_here
 POSTGRES_PASSWORD=a7f3c8e2-4b1d-4f9a-8c3e-7d2f1a9b5e4c
 ```
 
+If Mailcow runs on the same Docker host and the public Mailcow hostname causes a NAT or certificate error, also add this to the local `.env` file:
+
+```env
+MAILCOW_HOSTNAME=mail.example.com
+```
+
+Leave `MAILCOW_HOSTNAME` unset when Mailcow runs on a separate host. See the [Environment Variables Reference](ENV_Settings.md#docker-host-gateway-routing) for details.
+
 > **💡 Tip:** After starting the application, you can configure most other settings from the web UI (Settings tab). See [Settings UI Guide](Settings_UI.md) for details.
 
 **Start:**

--- a/documentation/SMTP_Abuse_Protection.md
+++ b/documentation/SMTP_Abuse_Protection.md
@@ -1,0 +1,151 @@
+# SMTP Abuse Protection
+
+This guide describes the optional SMTP abuse protection feature in mailcow Logs Viewer.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Requirements](#requirements)
+3. [Configuration](#configuration)
+4. [Security UI](#security-ui)
+5. [API](#api)
+6. [Notifications](#notifications)
+7. [Deployment](#deployment)
+8. [Safety Notes](#safety-notes)
+
+---
+
+## Overview
+
+The feature counts correlated outbound messages in a rolling time window. When a mailbox exceeds the configured threshold, the application can disable SMTP sending for that mailbox. The Security activity view also displays internal SMTP activity for visibility, but internal messages do not trigger automatic blocking.
+
+- Only `smtp_access` is changed.
+- IMAP and SOGo remain enabled.
+- App passwords are revoked when SMTP is blocked.
+- The mailbox receives a security notification when SMTP notifications are configured.
+- Whitelisted mailboxes are excluded from automatic blocking.
+- Automatic actions are recorded in the `smtp_abuse_actions` table.
+- Incoming-only mailboxes with SMTP intentionally disabled are not shown unless this system recorded a block for them.
+
+The scheduler checks once per minute. Newly imported messages can take a short time to appear because they must first pass through log ingestion and correlation.
+
+## Requirements
+
+The following are required:
+
+- `MAILCOW_API_KEY` for log ingestion.
+- `MAILCOW_API_KEY_RW` with permission to edit mailboxes and delete app passwords.
+- SMTP notification settings if users should receive block notifications.
+- A container image built from this fork.
+
+## Configuration
+
+Add the following to `.env`:
+
+```env
+SMTP_ABUSE_ENABLED=true
+SMTP_ABUSE_THRESHOLD=100
+SMTP_ABUSE_WINDOW_MINUTES=60
+SMTP_ABUSE_HELP_ADDRESS=example@example.com
+```
+
+Automatic enforcement is disabled unless `SMTP_ABUSE_ENABLED=true`. The default threshold is 100 messages during 60 minutes.
+
+## Security UI
+
+Open the **Security** tab and expand **Abuse Protection**, directly below the **Fail2ban IP Lists** section, to:
+
+- Click **Edit whitelist** to edit one email address per line, then click **Save whitelist**.
+- Filter the saved whitelist entries.
+- View the top 10 SMTP activity mailboxes, five per page.
+- Close SMTP from a row action or enter any mailbox address in the single-mailbox field.
+- Re-enable SMTP for a mailbox from the closed-mailbox list.
+
+When protection is disabled or `MAILCOW_API_KEY_RW` is unavailable, the panel displays a lock overlay and write controls are unavailable.
+
+Re-enabling SMTP does not change IMAP or SOGo access. A mailbox can be automatically blocked again if it exceeds the threshold after it is removed from the whitelist.
+
+## API
+
+All endpoints require application authentication:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/smtp-abuse/status` | View counts, threshold, and whitelist state |
+| `GET` | `/api/smtp-abuse/whitelist` | List whitelist entries |
+| `POST` | `/api/smtp-abuse/whitelist` | Add or reactivate a whitelist entry |
+| `PUT` | `/api/smtp-abuse/whitelist` | Replace the active whitelist; one email per list item |
+| `DELETE` | `/api/smtp-abuse/whitelist/{email}` | Deactivate a whitelist entry |
+| `POST` | `/api/smtp-abuse/mailboxes/{email}/block` | Disable SMTP and revoke app passwords |
+| `POST` | `/api/smtp-abuse/mailboxes/{email}/unblock` | Re-enable SMTP only |
+
+Whitelist request body:
+
+```json
+{
+  "email": "trusted@example.com",
+  "notes": "Monitoring mailbox"
+}
+```
+
+The bulk whitelist editor uses this request body:
+
+```json
+{
+  "emails": [
+    "trusted@example.com",
+    "monitoring@example.com"
+  ]
+}
+```
+
+`PUT /api/smtp-abuse/whitelist` replaces the active list. An email removed from the submitted list is deactivated.
+
+Write operations require both `SMTP_ABUSE_ENABLED=true` and `MAILCOW_API_KEY_RW`. The application authentication middleware protects all endpoints; keep the Logs Viewer restricted to administrators because these operations can modify mailbox SMTP access.
+
+## Notifications
+
+Block notifications use the existing global SMTP settings:
+
+```env
+SMTP_ENABLED=true
+SMTP_HOST=mail.example.com
+SMTP_PORT=587
+SMTP_USE_TLS=true
+SMTP_USER=...
+SMTP_PASSWORD=...
+SMTP_FROM=...
+```
+
+If notification SMTP is not configured, the mailbox is still blocked and the event is logged, but no email is sent.
+
+The current notification subject and plaintext email are stored in `backend/app/routers/smtp_abuse.py`, inside the `notify_blocked()` function. The current message is in English. The HTML body is generated automatically from the plaintext body by converting line breaks to `<br>` elements. Separate editable template files are not currently used.
+
+## Deployment
+
+After changing environment variables or source code, rebuild and restart the application:
+
+```bash
+cd /opt/mailcow-logs
+sudo docker compose up -d --build app
+```
+
+Verify the application health:
+
+```bash
+curl http://localhost:8080/api/health
+```
+
+## Safety Notes
+
+- Keep automatic enforcement disabled until the threshold has been reviewed.
+- Start with a threshold appropriate for the normal sending pattern of the installation.
+- Whitelist known high-volume service accounts before enabling enforcement.
+- Protect the read-write Mailcow API key because it grants mailbox modification capability.
+- Restrict access to the Logs Viewer to trusted administrators; the feature follows the application’s authentication boundary and does not currently implement a separate Keycloak role check.
+
+---
+
+For the environment variable reference, see [ENV Settings](ENV_Settings.md). For the complete API reference, see [API Documentation](API.md).

--- a/env.example
+++ b/env.example
@@ -8,6 +8,10 @@
 # Your mailcow instance URL (without trailing slash)
 MAILCOW_URL=https://mail.example.com
 
+# Optional: hostname used to reach Mailcow through the Docker host gateway
+# when Mailcow runs on the same Docker host. Keep this in local .env only.
+# MAILCOW_HOSTNAME=mail.example.com
+
 # mailcow API key - Read-Only (generate from System → API in mailcow admin)
 # Required permissions: Read access to logs
 MAILCOW_API_KEY=your-api-key-here
@@ -42,6 +46,16 @@ POSTGRES_PORT=5432
 # Default: false (all configuration from ENV only)
 # IMPORTANT: Must be in .env (or docker-compose environment) and app must be restarted after change.
 SETTINGS_EDIT_VIA_UI_ENABLED=true
+
+# =============================================================================
+# SMTP ABUSE PROTECTION (optional; disabled by default)
+# =============================================================================
+# Requires MAILCOW_API_KEY_RW. Blocks only SMTP; IMAP and SOGo remain enabled.
+# SMTP notifications use the SMTP_* settings documented below.
+# SMTP_ABUSE_ENABLED=false
+# SMTP_ABUSE_THRESHOLD=100
+# SMTP_ABUSE_WINDOW_MINUTES=60
+# SMTP_ABUSE_HELP_ADDRESS=example@example.com
 
 # =============================================================================
 # NOTE: All other settings can be configured via the web UI

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1426,6 +1426,7 @@ function switchTab(tab, params = {}) {
         case 'netfilter':
             loadNetfilterLogs(1);
             loadFail2BanSettings();
+            loadSmtpAbusePanel();
             loadNetfilterCountries();
             loadSecurityCountryChart(30);
             break;
@@ -4895,7 +4896,8 @@ function renderStatusJobs(jobs) {
             icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>',
             jobs: [
                 ['DNS Check (All Domains)', 'dns_check', jobs.dns_check],
-                ['IP Blacklist Check (All Hosts)', 'blacklist_check', jobs.blacklist_check]
+                ['IP Blacklist Check (All Hosts)', 'blacklist_check', jobs.blacklist_check],
+                ['SMTP Abuse Protection', 'smtp_abuse', jobs.smtp_abuse]
             ]
         },
         {
@@ -8588,6 +8590,168 @@ function renderSettings(content, data) {
             };
         }
     }
+
+}
+
+let smtpAbusePage = 1;
+let smtpAbuseStatus = null;
+let smtpAbuseWhitelist = [];
+let smtpWhitelistEditing = false;
+
+async function loadSmtpAbusePanel() {
+    const panel = document.getElementById('smtp-abuse-panel');
+    if (!panel) return;
+
+    panel.innerHTML = '<div class="p-6 text-sm text-gray-500 dark:text-gray-400">Loading abuse protection...</div>';
+
+    try {
+        const [statusResponse, whitelistResponse] = await Promise.all([
+            authenticatedFetch('/api/smtp-abuse/status?limit=10'),
+            authenticatedFetch('/api/smtp-abuse/whitelist')
+        ]);
+        if (!statusResponse.ok || !whitelistResponse.ok) throw new Error('HTTP error');
+        smtpAbuseStatus = await statusResponse.json();
+        smtpAbuseWhitelist = await whitelistResponse.json();
+        renderSmtpAbusePanel();
+    } catch (error) {
+        panel.innerHTML = '<div class="p-6 text-sm text-red-600">Could not load abuse protection.</div>';
+        console.error('SMTP abuse panel error:', error);
+    }
+}
+
+function renderSmtpAbusePanel() {
+    const panel = document.getElementById('smtp-abuse-panel');
+    if (!panel || !smtpAbuseStatus) return;
+    const status = smtpAbuseStatus;
+    const protectionLocked = !mailcowRwConfigured || !status.enabled;
+    const filter = (document.getElementById('smtp-abuse-whitelist-filter')?.value || '').toLowerCase();
+    const filteredWhitelist = smtpAbuseWhitelist.filter(item => item.email.toLowerCase().includes(filter));
+    const allRows = status.mailboxes || [];
+    const closedRows = allRows.filter(item => item.smtp_access === false);
+    const activityRows = allRows.filter(item => item.smtp_access !== false);
+    const pageCount = Math.max(1, Math.ceil(activityRows.length / 5));
+    smtpAbusePage = Math.min(smtpAbusePage, pageCount);
+    const pageRows = activityRows.slice((smtpAbusePage - 1) * 5, smtpAbusePage * 5);
+    const renderMailboxRow = item => `
+            <tr class="border-t border-gray-200 dark:border-gray-700">
+                <td class="px-4 py-3 font-mono text-sm text-gray-900 dark:text-white">${escapeHtml(item.email)}</td>
+                <td class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">${item.message_count}</td>
+                <td class="px-4 py-3">${item.whitelisted ? '<span class="text-green-600">Whitelisted</span>' : (item.over_threshold ? '<span class="text-red-600 font-medium">Over limit</span>' : '<span class="text-gray-500">Normal</span>')}</td>
+                <td class="px-4 py-3 text-right whitespace-nowrap">${item.smtp_access === false
+                    ? `<button onclick="smtpAbuseAction('${escapeJsArg(encodeURIComponent(item.email))}', 'unblock')" class="px-2 py-1 text-xs rounded bg-green-600 hover:bg-green-700 text-white">Open SMTP</button>`
+                    : `<button onclick="smtpAbuseAction('${escapeJsArg(encodeURIComponent(item.email))}', 'block')" class="px-2 py-1 text-xs rounded bg-red-600 hover:bg-red-700 text-white">Close SMTP</button>`}
+                </td>
+            </tr>`;
+    const rows = pageRows.map(renderMailboxRow).join('');
+    const closedMailboxRows = closedRows.map(renderMailboxRow).join('');
+    const whitelistRows = filteredWhitelist.map(item => `
+            <li class="flex items-center justify-between gap-3 py-2 border-t border-gray-200 dark:border-gray-700">
+                <span class="font-mono text-sm text-gray-900 dark:text-white">${escapeHtml(item.email)}</span>
+                <button onclick="removeSmtpAbuseWhitelist('${escapeJsArg(encodeURIComponent(item.email))}')" class="text-xs text-red-600 hover:underline">Remove</button>
+            </li>`).join('');
+    panel.innerHTML = `
+            <div class="p-4 border-b border-gray-200 dark:border-gray-700">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">SMTP abuse protection</h3>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">${status.enabled ? `Automatic blocking is enabled: more than ${status.threshold} messages in ${status.window_minutes} minutes.` : 'Automatic blocking is disabled. Configure SMTP_ABUSE_ENABLED and the threshold in the environment.'}</p>
+            </div>
+            <div class="p-4 space-y-6">
+                <form onsubmit="saveSmtpAbuseWhitelist(event)" class="space-y-2">
+                    <div class="flex items-center justify-between gap-2">
+                        <div><label for="smtp-abuse-whitelist-textarea" class="font-medium text-gray-900 dark:text-white block">Whitelist</label><p class="text-xs text-gray-500 dark:text-gray-400">One email address per line, like the Fail2ban IP lists.</p></div>
+                        ${smtpWhitelistEditing ? '' : '<button type="button" onclick="editSmtpAbuseWhitelist()" class="px-3 py-1.5 bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg">Edit whitelist</button>'}
+                    </div>
+                    <textarea id="smtp-abuse-whitelist-textarea" rows="5" placeholder="trusted@example.com&#10;monitoring@example.com" ${smtpWhitelistEditing ? '' : 'disabled'} class="w-full px-2 py-1.5 text-sm font-mono rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-green-700 dark:text-green-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y disabled:opacity-60">${escapeHtml(smtpAbuseWhitelist.map(item => item.email).join('\n'))}</textarea>
+                    ${smtpWhitelistEditing ? '<div class="flex justify-end"><button type="submit" class="px-3 py-2 rounded bg-blue-600 hover:bg-blue-700 text-white text-sm">Save whitelist</button></div>' : ''}
+                </form>
+                <div>
+                    <div class="flex flex-wrap items-center justify-between gap-2 mb-2"><h4 class="font-medium text-gray-900 dark:text-white">Whitelisted mailboxes</h4><input id="smtp-abuse-whitelist-filter" type="search" value="${escapeHtml(filter)}" oninput="renderSmtpAbusePanel()" placeholder="Filter whitelist" class="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm"></div>
+                    <ul>${whitelistRows || '<li class="text-sm text-gray-500">No matching whitelist entries</li>'}</ul>
+                </div>
+                <form onsubmit="closeSingleSmtpMailbox(event)" class="flex flex-wrap gap-2 border-t border-gray-200 dark:border-gray-700 pt-4">
+                    <input id="smtp-abuse-close-email" type="email" required placeholder="Close SMTP for this email" class="flex-1 min-w-56 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm">
+                    <button class="px-3 py-2 rounded bg-red-600 hover:bg-red-700 text-white text-sm">Close SMTP</button>
+                </form>
+                ${closedRows.length ? `<div><h4 class="font-medium text-gray-900 dark:text-white mb-2">SMTP-closed mailboxes</h4><div class="overflow-x-auto"><table class="w-full"><thead><tr class="text-left text-xs uppercase text-gray-500"><th class="px-4 py-2">Mailbox</th><th class="px-4 py-2">Messages</th><th class="px-4 py-2">Status</th><th class="px-4 py-2"></th></tr></thead><tbody>${closedMailboxRows}</tbody></table></div></div>` : ''}
+                <div><h4 class="font-medium text-gray-900 dark:text-white mb-2">Top 10 SMTP activity</h4><div class="overflow-x-auto"><table class="w-full"><thead><tr class="text-left text-xs uppercase text-gray-500"><th class="px-4 py-2">Mailbox</th><th class="px-4 py-2">Messages</th><th class="px-4 py-2">Status</th><th class="px-4 py-2"></th></tr></thead><tbody>${rows || '<tr><td colspan="4" class="px-4 py-3 text-sm text-gray-500">No SMTP activity in the current window</td></tr>'}</tbody></table></div>
+                <div class="flex justify-center items-center gap-3 mt-4"><button onclick="smtpAbusePage--; renderSmtpAbusePanel()" ${smtpAbusePage === 1 ? 'disabled' : ''} class="px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 rounded disabled:opacity-50">Previous</button><span class="text-sm text-gray-600 dark:text-gray-400">Page ${smtpAbusePage} of ${pageCount}</span><button onclick="smtpAbusePage++; renderSmtpAbusePanel()" ${smtpAbusePage === pageCount ? 'disabled' : ''} class="px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 rounded disabled:opacity-50">Next</button></div></div>
+                </div>
+            </div>`;
+    panel.classList.add('relative');
+    const lockReasons = [];
+    if (!mailcowRwConfigured) lockReasons.push('a Read-Write Mailcow API key is missing');
+    if (!status.enabled) lockReasons.push('SMTP abuse protection is disabled');
+    if (protectionLocked) {
+        panel.insertAdjacentHTML('afterbegin', `
+            <div class="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-white/80 dark:bg-gray-900/85 backdrop-blur-[1px] p-6">
+                <div class="max-w-lg text-center">
+                    <div class="text-3xl mb-2">🔒</div>
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Abuse protection is locked</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">Enable SMTP abuse protection and configure ${!mailcowRwConfigured ? '<code>MAILCOW_API_KEY_RW</code>' : 'the protection setting'} to use these controls.</p>
+                    <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">${escapeHtml(lockReasons.join(' and '))}.</p>
+                </div>
+            </div>`);
+    }
+}
+
+async function closeSingleSmtpMailbox(event) {
+    event.preventDefault();
+    const input = document.getElementById('smtp-abuse-close-email');
+    await smtpAbuseAction(encodeURIComponent(input.value), 'block');
+}
+
+async function smtpAbuseAction(encodedEmail, action) {
+    const email = decodeURIComponent(encodedEmail);
+    const response = await authenticatedFetch(`/api/smtp-abuse/mailboxes/${encodeURIComponent(email)}/${action}`, { method: 'POST' });
+    if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        showToast(detail.detail || `Could not ${action} SMTP`, 'error');
+        return;
+    }
+    showToast(action === 'block' ? 'SMTP blocked' : 'SMTP re-enabled', 'success');
+    loadSmtpAbusePanel();
+}
+
+async function addSmtpAbuseWhitelist(event) {
+    event.preventDefault();
+    const response = await authenticatedFetch('/api/smtp-abuse/whitelist', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: document.getElementById('smtp-abuse-whitelist-email').value, notes: document.getElementById('smtp-abuse-whitelist-notes').value })
+    });
+    if (!response.ok) { showToast('Could not update whitelist', 'error'); return; }
+    showToast('Whitelist updated', 'success');
+    loadSmtpAbusePanel();
+}
+
+async function saveSmtpAbuseWhitelist(event) {
+    event.preventDefault();
+    const emails = document.getElementById('smtp-abuse-whitelist-textarea').value
+        .split(/\r?\n/).map(email => email.trim()).filter(Boolean);
+    const response = await authenticatedFetch('/api/smtp-abuse/whitelist', {
+        method: 'PUT', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ emails })
+    });
+    if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        showToast(detail.detail || 'Could not save whitelist', 'error');
+        return;
+    }
+    smtpWhitelistEditing = false;
+    showToast('Whitelist saved', 'success');
+    loadSmtpAbusePanel();
+}
+
+function editSmtpAbuseWhitelist() {
+    smtpWhitelistEditing = true;
+    renderSmtpAbusePanel();
+    document.getElementById('smtp-abuse-whitelist-textarea')?.focus();
+}
+
+async function removeSmtpAbuseWhitelist(encodedEmail) {
+    const email = decodeURIComponent(encodedEmail);
+    const response = await authenticatedFetch(`/api/smtp-abuse/whitelist/${encodeURIComponent(email)}`, { method: 'DELETE' });
+    if (!response.ok) { showToast('Could not remove whitelist entry', 'error'); return; }
+    showToast('Whitelist entry removed', 'success');
+    loadSmtpAbusePanel();
 }
 
 async function showGeoIPSetupModal() {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1178,6 +1178,31 @@
                     </details>
                 </div>
 
+                <!-- SMTP Abuse Protection -->
+                <div class="mb-4">
+                    <details
+                        class="group bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-900/30 overflow-hidden">
+                        <summary
+                            class="list-none px-6 py-4 border-b border-gray-200 dark:border-gray-700 cursor-pointer flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors select-none">
+                            <h2 class="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                                <svg class="w-5 h-5 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"></path>
+                                </svg>
+                                Abuse Protection
+                            </h2>
+                            <svg class="w-5 h-5 text-gray-400 transition-transform duration-200 group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                            </svg>
+                        </summary>
+                        <div id="smtp-abuse-panel" class="p-4 sm:p-6">
+                            <div class="text-center py-6">
+                                <div class="loading mx-auto mb-4"></div>
+                                <p class="text-gray-500 dark:text-gray-400">Loading abuse protection...</p>
+                            </div>
+                        </div>
+                    </details>
+                </div>
+
                 <!-- Filters -->
                 <div class="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-900/30 p-4 mb-4">
                 <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">


### PR DESCRIPTION
This pull request contains the SMTP abuse protection and security-monitoring features I added to my fork.

I would appreciate your review to see whether these changes are suitable for inclusion in the main project. Please feel free to suggest changes or decide whether any parts should be included.

## Summary

Adds SMTP abuse protection and related security-monitoring features.

## Changes

- Adds SMTP abuse detection using outbound Postfix statistics.
- Adds configurable message threshold and rolling time window.
- Adds automatic SMTP blocking through the Mailcow API.
- Adds manual SMTP close/re-enable controls.
- Keeps IMAP access available when SMTP is blocked.
- Adds abuse whitelist management with one email per line.
- Adds abuse notification emails with configurable help contact.
- Adds SMTP abuse status and monitoring to Security & Monitoring.
- Excludes incoming-only mailboxes from abuse listings.
- Adds documentation for configuration, security behavior, and email templates.
- Documents same-host Docker host-gateway routing.
- Keeps deployment examples free of personal domains and addresses.

## Testing

- Verified Docker Compose configuration.
- Verified Python application compilation.
- Verified clean Git diff.
- Verified no personal domain, email address, or LAN IP is present in committed files.
- Tested Mailcow API connectivity from the running container.
- Confirmed `/api/quarantine` no longer fails because of the certificate-routing issue.
- Confirmed remote-host deployments can leave `MAILCOW_HOSTNAME` unset.